### PR TITLE
C++20とclangd開発環境のセットアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ compile_flags.txt
 # Build artifacts
 bin/
 build/
+compile_commands.json
+main.plist
+.cache/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TARGET := $(BINDIR)/main
 LDFLAGS := -lncursesw
 
 CXX := g++
-CXXFLAGS := -Wall -MMD -I$(INCDIR)
+CXXFLAGS := -Wall -MMD -I$(INCDIR) -std=c++20
 MAIN_CXXFLAGS := -D_XOPEN_SOURCE_EXTENDED
 
 # cppファイル取得


### PR DESCRIPTION
- `Makefile`にてC++20標準を使用するようにコンパイルフラグの追加．
- `.gitignore`に`compile_commands.json`と，一時ファイル・フォルダの`main.plist`，`.cache`を追加．
 