### PR TITLE
[feat] add: キーボードで選択した色を描画する機能の追加（#2）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ compile_flags.txt
 bin/
 build/
 compile_commands.json
-main.plist
+*.plist
 .cache/

--- a/include/core/ApplicationSettings.hpp
+++ b/include/core/ApplicationSettings.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+class ApplicationSettings
+{
+public:
+    static int BaseColorChangeStepValue;
+    static int ShiftColorChangeStepValue;
+
+};

--- a/include/core/KeyConstants.hpp
+++ b/include/core/KeyConstants.hpp
@@ -9,20 +9,6 @@ public:
     // 同一の操作に割り当て可能なキーの最大数
     static constexpr int MAX_REGISTABLE_KEY = 2;
 
-    static bool isKeyInput(int key, const std::optional<int> keyBind[2])
-    {
-        if (!keyBind[0].has_value() && !keyBind[1].has_value())
-            return false;
-
-        if (!keyBind[1].has_value())
-            return keyBind[0].value() == key;
-
-        if (!keyBind[0].has_value())
-            return false;
-        else
-            return keyBind[0] == key || keyBind[1] == key;
-    }
-
     // カーソル移動
     static constexpr std::optional<int> MOVE_CURSOR_LEFT_KEY[MAX_REGISTABLE_KEY] = {'h', KEY_LEFT};
     static constexpr std::optional<int> MOVE_CURSOR_DOWN_KEY[MAX_REGISTABLE_KEY] = {'j', KEY_DOWN};
@@ -39,11 +25,11 @@ public:
     static constexpr std::optional<int> EXECUTE_DEBUG_PROCESS_KEY[MAX_REGISTABLE_KEY] = {'d', };
 
     // 描画色RGB変更
-    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'a'};
-    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'s'};
-    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'d'};
+    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'a', };
+    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'s', };
+    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'d', };
     
-    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'z'};
-    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'x'};
-    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'c'};
+    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'z', };
+    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'x', };
+    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'c', };
 };

--- a/include/core/KeyConstants.hpp
+++ b/include/core/KeyConstants.hpp
@@ -1,36 +1,49 @@
 #pragma once
 
 #include <ncurses.h>
+#include <optional>
 
 class KeyConstants
 {
+public:
     // 同一の操作に割り当て可能なキーの最大数
     static constexpr int MAX_REGISTABLE_KEY = 2;
 
-public:
-    static bool isKeyInput(int key, const int keyBind[2])
+    static bool isKeyInput(int key, const std::optional<int> keyBind[2])
     {
-        return keyBind[0] == key || keyBind[1] == key;
+        if (!keyBind[0].has_value() && !keyBind[1].has_value())
+            return false;
+
+        if (!keyBind[1].has_value())
+            return keyBind[0].value() == key;
+
+        if (!keyBind[0].has_value())
+            return false;
+        else
+            return keyBind[0] == key || keyBind[1] == key;
     }
 
     // カーソル移動
-    static constexpr int MOVE_CURSOR_LEFT_KEY[MAX_REGISTABLE_KEY] = {'h', KEY_LEFT};
-    static constexpr int MOVE_CURSOR_DOWN_KEY[MAX_REGISTABLE_KEY] = {'j', KEY_DOWN};
-    static constexpr int MOVE_CURSOR_UP_KEY[MAX_REGISTABLE_KEY] = {'k', KEY_UP};
-    static constexpr int MOVE_CURSOR_RIGHT[MAX_REGISTABLE_KEY] = {'l', KEY_RIGHT};
+    static constexpr std::optional<int> MOVE_CURSOR_LEFT_KEY[MAX_REGISTABLE_KEY] = {'h', KEY_LEFT};
+    static constexpr std::optional<int> MOVE_CURSOR_DOWN_KEY[MAX_REGISTABLE_KEY] = {'j', KEY_DOWN};
+    static constexpr std::optional<int> MOVE_CURSOR_UP_KEY[MAX_REGISTABLE_KEY] = {'k', KEY_UP};
+    static constexpr std::optional<int> MOVE_CURSOR_RIGHT_KEY[MAX_REGISTABLE_KEY] = {'l', KEY_RIGHT};
 
     // 塗り
-    static constexpr int DRAW_KEY[MAX_REGISTABLE_KEY] = {32, };
+    static constexpr std::optional<int> DRAW_KEY[MAX_REGISTABLE_KEY] = {32, };
 
     // アプリ終了
-    static constexpr int PROGRAM_QUIT_KEY[MAX_REGISTABLE_KEY] = {'q', };
+    static constexpr std::optional<int> PROGRAM_QUIT_KEY[MAX_REGISTABLE_KEY] = {'q', };
+
+    // デバッグ実行
+    static constexpr std::optional<int> EXECUTE_DEBUG_PROCESS_KEY[MAX_REGISTABLE_KEY] = {'d', };
 
     // 描画色RGB変更
-    static constexpr int INCREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'a'};
-    static constexpr int INCREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'s'};
-    static constexpr int INCREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'d'};
+    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'a'};
+    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'s'};
+    static constexpr std::optional<int> INCREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'d'};
     
-    static constexpr int DECREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'z'};
-    static constexpr int DECREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'x'};
-    static constexpr int DECREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'c'};
+    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'z'};
+    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'x'};
+    static constexpr std::optional<int> DECREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'c'};
 };

--- a/include/core/KeyConstants.hpp
+++ b/include/core/KeyConstants.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ncurses.h>
+
+class KeyConstants
+{
+    // 同一の操作に割り当て可能なキーの最大数
+    static constexpr int MAX_REGISTABLE_KEY = 2;
+
+public:
+    static bool isKeyInput(int key, const int keyBind[2])
+    {
+        return keyBind[0] == key || keyBind[1] == key;
+    }
+
+    // カーソル移動
+    static constexpr int MOVE_CURSOR_LEFT_KEY[MAX_REGISTABLE_KEY] = {'h', KEY_LEFT};
+    static constexpr int MOVE_CURSOR_DOWN_KEY[MAX_REGISTABLE_KEY] = {'j', KEY_DOWN};
+    static constexpr int MOVE_CURSOR_UP_KEY[MAX_REGISTABLE_KEY] = {'k', KEY_UP};
+    static constexpr int MOVE_CURSOR_RIGHT[MAX_REGISTABLE_KEY] = {'l', KEY_RIGHT};
+
+    // 塗り
+    static constexpr int DRAW_KEY[MAX_REGISTABLE_KEY] = {32, };
+
+    // アプリ終了
+    static constexpr int PROGRAM_QUIT_KEY[MAX_REGISTABLE_KEY] = {'q', };
+
+    // 描画色RGB変更
+    static constexpr int INCREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'a'};
+    static constexpr int INCREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'s'};
+    static constexpr int INCREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'d'};
+    
+    static constexpr int DECREASE_CURRENTCOLOR_R_KEY[MAX_REGISTABLE_KEY] = {'z'};
+    static constexpr int DECREASE_CURRENTCOLOR_G_KEY[MAX_REGISTABLE_KEY] = {'x'};
+    static constexpr int DECREASE_CURRENTCOLOR_B_KEY[MAX_REGISTABLE_KEY] = {'c'};
+};

--- a/include/graphics/Color.hpp
+++ b/include/graphics/Color.hpp
@@ -52,12 +52,13 @@ private:
     static bool isInitialized;
 
 
-    static bool initNcursesColor(NcColorID colorNumber, uint8_t r, uint8_t g, uint8_t b);
 
 public:
+    static bool initNcursesColor(NcColorID colorNumber, uint8_t r, uint8_t g, uint8_t b);
 
     static void Initialize();
     static NcColorID allocateNcursesColor(uint8_t r, uint8_t g, uint8_t b);
+    static NcColorID allocateNcursesColor(RGB rgb);
     static void deleteNcursesColor(NcColorID targetIndex);
 
     static RGB getRGBFromColor(NcColorID color);

--- a/include/graphics/ColorPair.hpp
+++ b/include/graphics/ColorPair.hpp
@@ -50,10 +50,11 @@ private:
     static std::deque<NcPairID> colorPalletes;
     static bool isInitialized;
 
-    static bool initNcursesColorPair(NcPairID colorPairNumber, Color::NcColorID fg, Color::NcColorID bg);
 
 
 public:
+    static bool initNcursesColorPair(NcPairID colorPairNumber, Color::NcColorID fg, Color::NcColorID bg);
+
     // 環境ごとに最大値が違う可能性があるので、MAX_COLOR コンパイルor実行時に可変にできたらいいかも
     static NcPairID const COLOR_PAIR_MAX = 65535;
 

--- a/include/ui/Canvas.hpp
+++ b/include/ui/Canvas.hpp
@@ -44,6 +44,8 @@ public:
     void move(Vector2 direction) override;
     void moveDirect(Vector2& direct_pos) override;
 
+    Vector2 getPos();
+
     // Printable Area
     void setPrintAreaLimit(const Vector2& lim_min, const Vector2& lim_max);
     void setPrintAreaLimit( int lim_min_x, int lim_min_y, 

--- a/include/ui/Footer.hpp
+++ b/include/ui/Footer.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "graphics/Color.hpp"
+#include "interfaces/IPrintable.hpp"
+#include "ui/FooterData.hpp"
+
+class Footer : public IPrintable
+{
+private:
+    FooterData data;
+    int windowSizeY;
+
+    void initNcursesCurrentColor(Color::RGB rgb);
+    void updateNcursesCurrentColor(Color::RGB rgb);
+    void setData(FooterData data, int windowSizeY);
+
+public:
+    Footer();
+    Footer(FooterData data, int windowSizeY);
+
+    void print() const override;
+    void print(Vector2 offset) const override;
+
+    void update(FooterData data, int windowSizeY);
+
+
+};

--- a/include/ui/FooterData.hpp
+++ b/include/ui/FooterData.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "core/Vector2.hpp"
+#include "graphics/Color.hpp"
+
+class FooterData
+{
+public:
+    Vector2 cursorPos;
+    Vector2 canvasPos;
+    Color::RGB currentRgb;
+
+    FooterData() {};
+    FooterData(Vector2 cursorPos, 
+               Vector2 canvasPos, 
+               Color::RGB currentRgb)
+        : cursorPos(cursorPos), 
+          canvasPos(canvasPos), 
+          currentRgb(currentRgb) {};
+};

--- a/include/ui/SidePanel.hpp
+++ b/include/ui/SidePanel.hpp
@@ -27,8 +27,8 @@ public:
     SidePanel(Vector2 windowSize, Vector2 printAreaLimitMin, Vector2 printAreaLimitMax);
     ~SidePanel();
 
-    void print() const;
-    void print(Vector2 offset) const;
+    void print() const override;
+    void print(Vector2 offset) const override;
 
     void update(Vector2 windowSize, 
             Vector2 printAreaLimitMin, 

--- a/src/core/ApplicationSettings.cpp
+++ b/src/core/ApplicationSettings.cpp
@@ -1,0 +1,5 @@
+
+#include "core/ApplicationSettings.hpp"
+
+int ApplicationSettings::BaseColorChangeStepValue = 1;
+int ApplicationSettings::ShiftColorChangeStepValue = 10;

--- a/src/graphics/Color.cpp
+++ b/src/graphics/Color.cpp
@@ -67,6 +67,11 @@ Color::NcColorID Color::allocateNcursesColor(uint8_t r, uint8_t g, uint8_t b)
     return insertIndex;
 }
 
+Color::NcColorID Color::allocateNcursesColor(Color::RGB rgb)
+{
+    return allocateNcursesColor(rgb.r, rgb.g, rgb.b);
+}
+
 /* deleting process */
 void Color::deleteNcursesColor(Color::NcColorID targetIndex)
 {

--- a/src/graphics/ColorPair.cpp
+++ b/src/graphics/ColorPair.cpp
@@ -184,3 +184,4 @@ void ColorPair::setCursorPairColor(bool isDefault)
         return;
     }
 }
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <clocale>
 #include <cstdint>
+#include <cctype>
 #include <functional>
 #include <ncurses.h>
 #include <optional>
@@ -204,21 +205,36 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
         ApplicationSettings::ShiftColorChangeStepValue
     };
 
-    // for (int step : steps)
-    // {
-        for (int idx = 0; idx < changeColorKeys.size(); idx++)
-        {
-            // 3以降は値減少キーだからマイナスにする必要がある
-            int8_t fact = ((idx >= 3) ? -1 : 1);
+    for (int idx = 0; idx < changeColorKeys.size(); idx++)
+    {
+        // 3以降は値減少キーだからマイナスにする必要がある
+        int8_t fact = ((idx >= 3) ? -1 : 1);
 
-            bindKeyAction(keyActionMap, 
-                changeColorKeys[idx], 
-                createChangeColorValueAction(
-                    context, 
-                    colorRgbPtrs[idx % 3],
-                    steps[0] * fact));
+        bindKeyAction(keyActionMap, 
+            changeColorKeys[idx], 
+            createChangeColorValueAction(
+                context, 
+                colorRgbPtrs[idx % 3],
+                steps[0] * fact));
+
+        std::optional<int> shiftedKeys[KeyConstants::MAX_REGISTABLE_KEY];
+        for (int keyIdx = 0; keyIdx < KeyConstants::MAX_REGISTABLE_KEY; keyIdx++)
+        {
+            // キーが設定されているかどうか
+            if (changeColorKeys[idx][keyIdx])
+                shiftedKeys[keyIdx] = std::toupper(changeColorKeys[idx][keyIdx].value());
+            else
+                shiftedKeys[keyIdx] = std::nullopt;
         }
-    // }
+
+        bindKeyAction(keyActionMap, 
+            shiftedKeys, 
+            createChangeColorValueAction(
+                context, 
+                colorRgbPtrs[idx % 3],
+                steps[1] * fact));
+    }
+    
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <tuple>
 
+#include "core/KeyConstants.hpp"
 #include "graphics/Color.hpp"
 #include "graphics/ColorPair.hpp"
 #include "core/Vector2.hpp"
@@ -178,37 +179,33 @@ int main()
         // 入力文字を取得
         ch = getch();
 
+        if (KeyConstants::isKeyInput(ch, KeyConstants::MOVE_CURSOR_LEFT_KEY))
+        {
+            cursor.move(Vector2::LEFT);
+        }
+        else if (KeyConstants::isKeyInput(ch, KeyConstants::MOVE_CURSOR_DOWN_KEY))
+        {
+            cursor.move(Vector2::DOWN);
+        }
+
         switch (ch)
         {
-            case 'h':
-            case KEY_LEFT:
-                {
-                    cursor.move(Vector2::LEFT);
-                }
-                break;
-
-            case 'j':
-            case KEY_DOWN:
-                {
-                    cursor.move(Vector2::DOWN);
-                }
-                break;
-
-            case 'k':
-            case KEY_UP:
+            case KeyConstants::MOVE_CURSOR_UP_KEY[0]:
+            case KeyConstants::MOVE_CURSOR_UP_KEY[1]:
                 {
                     cursor.move(Vector2::UP);
                 }
                 break;
 
-            case 'l':
-            case KEY_RIGHT:
+            case KeyConstants::MOVE_CURSOR_RIGHT[0]:
+            case KeyConstants::MOVE_CURSOR_RIGHT[1]:
                 {
                     cursor.move(Vector2::RIGHT);
                 }
                 break;
 
-            case 'q':
+            case KeyConstants::PROGRAM_QUIT_KEY[0]:
+            case KeyConstants::PROGRAM_QUIT_KEY[1]:
                 {
                     isClose = true;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,13 @@
 
 #include <clocale>
 #include <cstdint>
+#include <functional>
 #include <ncurses.h>
+#include <optional>
 #include <random>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 
 #include "core/KeyConstants.hpp"
 #include "graphics/Color.hpp"
@@ -63,6 +66,107 @@ void debugAction(Canvas& canvas, Cursor& cursor)
 
 }
 
+struct AppContext
+{
+    bool isClose = false;
+    Color::RGB currentRgb;
+    std::optional<std::reference_wrapper<Canvas>> canvas;
+    std::optional<std::reference_wrapper<Cursor>> cursor;
+    std::mt19937 mt{std::random_device{}()};
+    std::uniform_int_distribution<int> dist{0, 255};
+};
+
+void bindKeyAction(
+        std::unordered_map<int, std::function<void()>>& keyActionMap, 
+        const std::optional<int> keys[2], 
+        std::function<void()> action)
+{
+    for (int idx = 0; idx < KeyConstants::MAX_REGISTABLE_KEY; idx++)
+    {
+        if (keys[idx].has_value())
+        { // キーが設定されている
+            keyActionMap[keys[idx].value()] = action;
+        }
+    }
+}
+
+void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionMap, AppContext& context)
+{
+    /* キーと関連つける処理定義 */
+    // プログラム終了フラグ
+    auto appQuit = [&]()
+    {
+        context.isClose = true;
+    };
+
+    auto draw = [&]()
+    {
+        if (!context.canvas || !context.cursor)
+        { // 少なくともどっちかが参照を持っていない
+            return;
+        }
+
+        Canvas& canvas = context.canvas->get();
+        Cursor& cursor = context.cursor->get();
+
+        Vector2 cpos = cursor.getCursorPos(); // キャンバスの正方形ピクセル座標
+        Vector2 canvasSize = canvas.getCanvasSize();
+
+        if (0 <= cpos.y && cpos.y < canvasSize.y &&
+            0 <= cpos.x && cpos.x < canvasSize.x)
+        {
+            context.currentRgb.r = context.dist(context.mt);
+            context.currentRgb.g = context.dist(context.mt);
+            context.currentRgb.b = context.dist(context.mt);
+
+            Color::NcColorID colnum = Color::allocateNcursesColor(context.currentRgb);
+            ColorPair::NcPairID pair = ColorPair::allocateNcursesColorPair(0, colnum);
+            canvas.getCurrentLayerIter()->setpx(cpos.y, cpos.x, pair);
+        }
+    };
+
+    auto moveLeft = [&]() 
+    {
+        if (context.cursor)
+            context.cursor->get().move(Vector2::LEFT);
+    };
+    auto moveDown = [&]()
+    {
+        if (context.cursor)
+            context.cursor->get().move(Vector2::DOWN);
+    };
+    auto moveUp = [&]() 
+    {
+        if (context.cursor)
+            context.cursor->get().move(Vector2::UP);
+    };
+    auto moveRight = [&]() 
+    {
+        if (context.cursor)
+            context.cursor->get().move(Vector2::RIGHT); 
+    };
+
+    auto debug = [&]() 
+    {
+        if (!context.canvas || !context.cursor)
+        { // 少なくともどっちかが参照を持っていない
+            return;
+        }
+
+        debugAction(context.canvas->get(), context.cursor->get());
+    };
+
+    /* キーと処理を関連つける */
+    bindKeyAction(keyActionMap, KeyConstants::PROGRAM_QUIT_KEY, appQuit);
+    bindKeyAction(keyActionMap, KeyConstants::DRAW_KEY, draw);
+    bindKeyAction(keyActionMap, KeyConstants::MOVE_CURSOR_LEFT_KEY, moveLeft);
+    bindKeyAction(keyActionMap, KeyConstants::MOVE_CURSOR_DOWN_KEY, moveDown);
+    bindKeyAction(keyActionMap, KeyConstants::MOVE_CURSOR_UP_KEY, moveUp);
+    bindKeyAction(keyActionMap, KeyConstants::MOVE_CURSOR_RIGHT_KEY, moveRight);
+    bindKeyAction(keyActionMap, KeyConstants::EXECUTE_DEBUG_PROCESS_KEY, debug);
+}
+
+
 int main()
 {
     Cursor cursor;
@@ -70,8 +174,9 @@ int main()
     Vector2 correctWindowSize;
     Vector2 moveLimitMin, moveLimitMax;
     Vector2 printAreaLimitMin, printAreaLimitMax;
-    Color::RGB currentRgb(0, 0, 0);
-
+    std::unordered_map<int, std::function<void()>> keyActionMap;
+    AppContext context;
+
     //setting
     setlocale(LC_ALL, "");
     
@@ -117,8 +222,8 @@ int main()
     Footer footer(
             FooterData(cursor.getCursorPos(), 
                              canvas.getPos(),
-                                        currentRgb), 
-            windowSize.y
+                             context.currentRgb), 
+            correctWindowSize.y
     );
 
     canvas.setMoveLimit(moveLimitMin, moveLimitMax);
@@ -126,12 +231,6 @@ int main()
     cursor.setMoveLimit(moveLimitMin, moveLimitMax);
 
     canvas.addLayer("layer");
-
-    // デバッグ用のランダム値生成装置作成
-    std::random_device rd;
-    std::mt19937 mt(rd());
-    std::uniform_int_distribution<> dist(0, 255);
-
 
     ColorPair::NcPairID cursorColorPair = canvas.getTopVisibleColorPair(cursor.getCursorPos());
     if (cursorColorPair != 0)
@@ -151,11 +250,15 @@ int main()
     cursor.print();
     refresh();
 
+    context.canvas = canvas;
+    context.cursor = cursor;
+    setupKeyBindings(keyActionMap, context);
+
     int ch;
-    bool isClose = false;
+    context.isClose = false;
 
     /* mainroop */
-    while (!isClose)
+    while (!context.isClose)
     {
         // 画面のリサイズに合わせて移動制限範囲を変更
         getmaxyx(stdscr, windowSize.y, windowSize.x);
@@ -179,76 +282,13 @@ int main()
         // 入力文字を取得
         ch = getch();
 
-        if (KeyConstants::isKeyInput(ch, KeyConstants::MOVE_CURSOR_LEFT_KEY))
+        if (keyActionMap.contains(ch))
         {
-            cursor.move(Vector2::LEFT);
+            keyActionMap[ch]();
         }
-        else if (KeyConstants::isKeyInput(ch, KeyConstants::MOVE_CURSOR_DOWN_KEY))
+        else
         {
-            cursor.move(Vector2::DOWN);
-        }
-
-        switch (ch)
-        {
-            case KeyConstants::MOVE_CURSOR_UP_KEY[0]:
-            case KeyConstants::MOVE_CURSOR_UP_KEY[1]:
-                {
-                    cursor.move(Vector2::UP);
-                }
-                break;
-
-            case KeyConstants::MOVE_CURSOR_RIGHT[0]:
-            case KeyConstants::MOVE_CURSOR_RIGHT[1]:
-                {
-                    cursor.move(Vector2::RIGHT);
-                }
-                break;
-
-            case KeyConstants::PROGRAM_QUIT_KEY[0]:
-            case KeyConstants::PROGRAM_QUIT_KEY[1]:
-                {
-                    isClose = true;
-                }
-                break;
-
-            case 'd':
-                {
-                    debugAction(canvas, cursor);
-                }
-                break;
-
-            // Space key
-            case 32:
-                {
-                    Vector2 cpos = cursor.getCursorPos(); // キャンバスの正方形ピクセル座標
-                    Vector2 canvasSize = canvas.getCanvasSize();
-
-                    if (0 <= cpos.y && cpos.y < canvasSize.y &&
-                        0 <= cpos.x && cpos.x < canvasSize.x)
-                    {
-                        currentRgb.r = dist(mt);
-                        currentRgb.g = dist(mt);
-                        currentRgb.b = dist(mt);
-
-                        Color::NcColorID colnum = Color::allocateNcursesColor(currentRgb);
-                        ColorPair::NcPairID pair = ColorPair::allocateNcursesColorPair(0, colnum);
-                        canvas.getCurrentLayerIter()->setpx(cpos.y, cpos.x, pair);
-                    }
-                }
-                break;
-
-
-            case ERR:
-                {
-
-                }
-                break;
-
-            default:
-                {
-
-                }
-                break;
+            mvprintw(correctWindowSize.y, 0, "Invalid Key");
         }
 
         // 描画処理
@@ -264,7 +304,7 @@ int main()
             Color::NcColorID cursorColor = ColorPair::getPairFromColorPair(cursorColorPair);
             Color::RGB cursorRgb = Color::getRGBFromColor(cursorColor);
 
-            int res = Color::setCursorColor(0, 0, 0, cursorRgb.r, cursorRgb.g, cursorRgb.b);
+            Color::setCursorColor(0, 0, 0, cursorRgb.r, cursorRgb.g, cursorRgb.b);
 
             ColorPair::setCursorPairColor();
         }
@@ -295,9 +335,9 @@ int main()
 
         footer.update(
             FooterData(cursor.getCursorPos(), 
-                             canvas.getPos(),
-                                        currentRgb), 
-            windowSize.y
+                       canvas.getPos(),
+                       context.currentRgb), 
+            correctWindowSize.y
         );
 
         footer.print();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 
+#include <algorithm>
 #include <clocale>
 #include <cstdint>
 #include <functional>
@@ -10,6 +11,7 @@
 #include <unordered_map>
 
 #include "core/KeyConstants.hpp"
+#include "core/ApplicationSettings.hpp"
 #include "graphics/Color.hpp"
 #include "graphics/ColorPair.hpp"
 #include "core/Vector2.hpp"
@@ -75,6 +77,12 @@ struct AppContext
     std::mt19937 mt{std::random_device{}()};
     std::uniform_int_distribution<int> dist{0, 255};
 };
+
+void changeColorValue(int& col, int step)
+{
+    col += step;
+    col = std::clamp(col, 0, 255);
+}
 
 void bindKeyAction(
         std::unordered_map<int, std::function<void()>>& keyActionMap, 
@@ -156,6 +164,39 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
         debugAction(context.canvas->get(), context.cursor->get());
     };
 
+    auto increaseColorValueRB = [&]()
+    {
+        changeColorValue(context.currentRgb.r, 
+                         ApplicationSettings::BaseColorChangeStepValue);
+    };
+    auto increaseColorValueGB = [&]()
+    {
+        changeColorValue(context.currentRgb.g, 
+                         ApplicationSettings::BaseColorChangeStepValue);
+    };
+    auto increaseColorValueBB = [&]()
+    {
+        changeColorValue(context.currentRgb.b, 
+                         ApplicationSettings::BaseColorChangeStepValue);
+    };
+
+    auto decreaseColorValueRB = [&]()
+    {
+        changeColorValue(context.currentRgb.r, 
+                         -ApplicationSettings::BaseColorChangeStepValue);
+    };
+    auto decreaseColorValueGB = [&]()
+    {
+        changeColorValue(context.currentRgb.g, 
+                         -ApplicationSettings::BaseColorChangeStepValue);
+    };
+    auto decreaseColorValueBB = [&]()
+    {
+        changeColorValue(context.currentRgb.b, 
+                         -ApplicationSettings::BaseColorChangeStepValue);
+    };
+
+
     /* キーと処理を関連つける */
     bindKeyAction(keyActionMap, KeyConstants::PROGRAM_QUIT_KEY, appQuit);
     bindKeyAction(keyActionMap, KeyConstants::DRAW_KEY, draw);
@@ -164,6 +205,13 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
     bindKeyAction(keyActionMap, KeyConstants::MOVE_CURSOR_UP_KEY, moveUp);
     bindKeyAction(keyActionMap, KeyConstants::MOVE_CURSOR_RIGHT_KEY, moveRight);
     bindKeyAction(keyActionMap, KeyConstants::EXECUTE_DEBUG_PROCESS_KEY, debug);
+
+    bindKeyAction(keyActionMap, KeyConstants::INCREASE_CURRENTCOLOR_R_KEY, increaseColorValueRB);
+    bindKeyAction(keyActionMap, KeyConstants::INCREASE_CURRENTCOLOR_G_KEY, increaseColorValueGB);
+    bindKeyAction(keyActionMap, KeyConstants::INCREASE_CURRENTCOLOR_B_KEY, increaseColorValueBB);
+    bindKeyAction(keyActionMap, KeyConstants::DECREASE_CURRENTCOLOR_R_KEY, decreaseColorValueRB);
+    bindKeyAction(keyActionMap, KeyConstants::DECREASE_CURRENTCOLOR_G_KEY, decreaseColorValueGB);
+    bindKeyAction(keyActionMap, KeyConstants::DECREASE_CURRENTCOLOR_B_KEY, decreaseColorValueBB);
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 
 #include <clocale>
+#include <cstdint>
 #include <ncurses.h>
 #include <random>
 #include <string>
@@ -8,9 +9,12 @@
 #include "graphics/Color.hpp"
 #include "graphics/ColorPair.hpp"
 #include "core/Vector2.hpp"
+#include "ui/FooterData.hpp"
 #include "ui/SidePanel.hpp"
 #include "ui/Canvas.hpp"
 #include "ui/Cursor.hpp"
+#include "ui/Footer.hpp"
+#include "ui/FooterData.hpp"
 
 void waitEnter()
 {
@@ -65,7 +69,8 @@ int main()
     Vector2 correctWindowSize;
     Vector2 moveLimitMin, moveLimitMax;
     Vector2 printAreaLimitMin, printAreaLimitMax;
-
+    Color::RGB currentRgb(0, 0, 0);
+
     //setting
     setlocale(LC_ALL, "");
     
@@ -107,6 +112,13 @@ int main()
             printAreaLimitMax,
             canvas.layers, 
             canvas.getCurrentLayerIter());
+
+    Footer footer(
+            FooterData(cursor.getCursorPos(), 
+                             canvas.getPos(),
+                                        currentRgb), 
+            windowSize.y
+    );
 
     canvas.setMoveLimit(moveLimitMin, moveLimitMax);
     canvas.setPrintAreaLimit(moveLimitMin, moveLimitMax);
@@ -217,7 +229,11 @@ int main()
                     if (0 <= cpos.y && cpos.y < canvasSize.y &&
                         0 <= cpos.x && cpos.x < canvasSize.x)
                     {
-                        Color::NcColorID colnum = Color::allocateNcursesColor(dist(mt), dist(mt), dist(mt));
+                        currentRgb.r = dist(mt);
+                        currentRgb.g = dist(mt);
+                        currentRgb.b = dist(mt);
+
+                        Color::NcColorID colnum = Color::allocateNcursesColor(currentRgb);
                         ColorPair::NcPairID pair = ColorPair::allocateNcursesColorPair(0, colnum);
                         canvas.getCurrentLayerIter()->setpx(cpos.y, cpos.x, pair);
                     }
@@ -263,9 +279,9 @@ int main()
         cursor.print();
 
         // 現在のカーソル位置を描画
-        attr_set(A_NORMAL, 0, NULL);
-        Vector2 cpos = cursor.getCursorPos();
-        mvprintw(windowSize.y - 2, 0, "(%d, %d)", cpos.x, cpos.y);
+        // attr_set(A_NORMAL, 0, NULL);
+        // Vector2 cpos = cursor.getCursorPos();
+        // mvprintw(windowSize.y - 2, 0, "(%d, %d)", cpos.x, cpos.y);
 
         // print可能な範囲
         std::tie(printAreaLimitMin, printAreaLimitMax)
@@ -279,6 +295,15 @@ int main()
             canvas.getCurrentLayerIter());
 
         sidePanel.print();
+
+        footer.update(
+            FooterData(cursor.getCursorPos(), 
+                             canvas.getPos(),
+                                        currentRgb), 
+            windowSize.y
+        );
+
+        footer.print();
 
         refresh();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,10 +132,6 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
         if (0 <= cpos.y && cpos.y < canvasSize.y &&
             0 <= cpos.x && cpos.x < canvasSize.x)
         {
-            context.currentRgb.r = context.dist(context.mt);
-            context.currentRgb.g = context.dist(context.mt);
-            context.currentRgb.b = context.dist(context.mt);
-
             Color::NcColorID colnum = Color::allocateNcursesColor(context.currentRgb);
             ColorPair::NcPairID pair = ColorPair::allocateNcursesColorPair(0, colnum);
             canvas.getCurrentLayerIter()->setpx(cpos.y, cpos.x, pair);
@@ -182,6 +178,8 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
     bindKeyAction(keyActionMap, KeyConstants::MOVE_CURSOR_RIGHT_KEY, moveRight);
     bindKeyAction(keyActionMap, KeyConstants::EXECUTE_DEBUG_PROCESS_KEY, debug);
 
+    // 小文字と大文字のRGB色操作のキーバインド
+    // 処理用変数定義
     const std::array<const std::optional<int>*, 6> 
     changeColorKeys = {
         KeyConstants::INCREASE_CURRENTCOLOR_R_KEY,
@@ -204,7 +202,8 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
         ApplicationSettings::BaseColorChangeStepValue,
         ApplicationSettings::ShiftColorChangeStepValue
     };
-
+    
+    // 実際の登録処理
     for (int idx = 0; idx < changeColorKeys.size(); idx++)
     {
         // 3以降は値減少キーだからマイナスにする必要がある
@@ -234,9 +233,7 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
                 colorRgbPtrs[idx % 3],
                 steps[1] * fact));
     }
-    
 }
-
 
 int main()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,8 +80,7 @@ struct AppContext
 
 void changeColorValue(int& col, int step)
 {
-    col += step;
-    col = std::clamp(col, 0, 255);
+    col = std::clamp(col + step, 0, 255);
 }
 
 void bindKeyAction(
@@ -96,6 +95,15 @@ void bindKeyAction(
             keyActionMap[keys[idx].value()] = action;
         }
     }
+}
+
+auto createChangeColorValueAction(AppContext& context,
+        int (Color::RGB::* changeValuePtr), 
+        int step)
+{
+    return [=, &context]() {
+        changeColorValue(context.currentRgb.*changeValuePtr, step);
+    };
 }
 
 void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionMap, AppContext& context)
@@ -164,39 +172,6 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
         debugAction(context.canvas->get(), context.cursor->get());
     };
 
-    auto increaseColorValueRB = [&]()
-    {
-        changeColorValue(context.currentRgb.r, 
-                         ApplicationSettings::BaseColorChangeStepValue);
-    };
-    auto increaseColorValueGB = [&]()
-    {
-        changeColorValue(context.currentRgb.g, 
-                         ApplicationSettings::BaseColorChangeStepValue);
-    };
-    auto increaseColorValueBB = [&]()
-    {
-        changeColorValue(context.currentRgb.b, 
-                         ApplicationSettings::BaseColorChangeStepValue);
-    };
-
-    auto decreaseColorValueRB = [&]()
-    {
-        changeColorValue(context.currentRgb.r, 
-                         -ApplicationSettings::BaseColorChangeStepValue);
-    };
-    auto decreaseColorValueGB = [&]()
-    {
-        changeColorValue(context.currentRgb.g, 
-                         -ApplicationSettings::BaseColorChangeStepValue);
-    };
-    auto decreaseColorValueBB = [&]()
-    {
-        changeColorValue(context.currentRgb.b, 
-                         -ApplicationSettings::BaseColorChangeStepValue);
-    };
-
-
     /* キーと処理を関連つける */
     bindKeyAction(keyActionMap, KeyConstants::PROGRAM_QUIT_KEY, appQuit);
     bindKeyAction(keyActionMap, KeyConstants::DRAW_KEY, draw);
@@ -206,12 +181,44 @@ void setupKeyBindings(std::unordered_map<int, std::function<void()>>& keyActionM
     bindKeyAction(keyActionMap, KeyConstants::MOVE_CURSOR_RIGHT_KEY, moveRight);
     bindKeyAction(keyActionMap, KeyConstants::EXECUTE_DEBUG_PROCESS_KEY, debug);
 
-    bindKeyAction(keyActionMap, KeyConstants::INCREASE_CURRENTCOLOR_R_KEY, increaseColorValueRB);
-    bindKeyAction(keyActionMap, KeyConstants::INCREASE_CURRENTCOLOR_G_KEY, increaseColorValueGB);
-    bindKeyAction(keyActionMap, KeyConstants::INCREASE_CURRENTCOLOR_B_KEY, increaseColorValueBB);
-    bindKeyAction(keyActionMap, KeyConstants::DECREASE_CURRENTCOLOR_R_KEY, decreaseColorValueRB);
-    bindKeyAction(keyActionMap, KeyConstants::DECREASE_CURRENTCOLOR_G_KEY, decreaseColorValueGB);
-    bindKeyAction(keyActionMap, KeyConstants::DECREASE_CURRENTCOLOR_B_KEY, decreaseColorValueBB);
+    const std::array<const std::optional<int>*, 6> 
+    changeColorKeys = {
+        KeyConstants::INCREASE_CURRENTCOLOR_R_KEY,
+        KeyConstants::INCREASE_CURRENTCOLOR_G_KEY,
+        KeyConstants::INCREASE_CURRENTCOLOR_B_KEY,
+        KeyConstants::DECREASE_CURRENTCOLOR_R_KEY,
+        KeyConstants::DECREASE_CURRENTCOLOR_G_KEY,
+        KeyConstants::DECREASE_CURRENTCOLOR_B_KEY
+    };
+
+    const std::array<int Color::RGB::*, 3> 
+    colorRgbPtrs = {
+        &Color::RGB::r,
+        &Color::RGB::g,
+        &Color::RGB::b
+    };
+
+    const std::array<int, 2>
+    steps = {
+        ApplicationSettings::BaseColorChangeStepValue,
+        ApplicationSettings::ShiftColorChangeStepValue
+    };
+
+    // for (int step : steps)
+    // {
+        for (int idx = 0; idx < changeColorKeys.size(); idx++)
+        {
+            // 3以降は値減少キーだからマイナスにする必要がある
+            int8_t fact = ((idx >= 3) ? -1 : 1);
+
+            bindKeyAction(keyActionMap, 
+                changeColorKeys[idx], 
+                createChangeColorValueAction(
+                    context, 
+                    colorRgbPtrs[idx % 3],
+                    steps[0] * fact));
+        }
+    // }
 }
 
 

--- a/src/ui/Canvas.cpp
+++ b/src/ui/Canvas.cpp
@@ -75,6 +75,11 @@ Vector2 Canvas::getCanvasSize()
 }
 
 
+Vector2 Canvas::getPos()
+{
+    return pos;
+}
+
 void Canvas::setMoveLimit(Vector2& lim_min, Vector2& lim_max)
 {
     this->lim_min = lim_min;

--- a/src/ui/Footer.cpp
+++ b/src/ui/Footer.cpp
@@ -1,0 +1,66 @@
+#include <ncurses.h>
+#include "ui/Footer.hpp"
+#include "core/Vector2.hpp"
+#include "graphics/Color.hpp"
+#include "ui/FooterData.hpp"
+#include "graphics/ColorPair.hpp"
+#include "graphics/ColorConstants.hpp"
+
+
+Footer::Footer()
+{
+    initNcursesCurrentColor(Color::RGB(0, 0, 0));
+}
+
+Footer::Footer(FooterData data, int windowSizeY)
+{
+    setData(data, windowSizeY);
+    initNcursesCurrentColor(data.currentRgb);
+
+}
+
+void Footer::print() const
+{
+    print(Vector2::ZERO);
+}
+
+
+void Footer::print(Vector2 offset) const
+{
+    attr_set(A_NORMAL, static_cast<ColorPair::NcPairID>(ReservedPairNumber::CURRENTCOLOR), NULL);
+    mvprintw(windowSizeY - 1, 0, "  ");
+
+    attr_set(A_NORMAL, 0, NULL);
+    
+    mvprintw(windowSizeY - 1, 20, "%d,%d", data.cursorPos.x, data.cursorPos.y);
+}
+
+void Footer::update(FooterData data, int windowSizeY)
+{
+    setData(data, windowSizeY);
+    updateNcursesCurrentColor(data.currentRgb);
+    
+
+}
+
+void Footer::initNcursesCurrentColor(Color::RGB rgb)
+{
+    ColorPair::NcPairID p = static_cast<ColorPair::NcPairID>(ReservedPairNumber::CURRENTCOLOR);
+    Color::NcColorID c = static_cast<Color::NcColorID>(ReservedColorNumber::CURRENTCOLOR);
+
+    Color::initNcursesColor(c, rgb.r, rgb.g, rgb.b);
+    ColorPair::initNcursesColorPair(p, c, c);
+}
+
+void Footer::updateNcursesCurrentColor(Color::RGB rgb)
+{
+    Color::NcColorID c = static_cast<Color::NcColorID>(ReservedColorNumber::CURRENTCOLOR);
+
+    Color::initNcursesColor(c, rgb.r, rgb.g, rgb.b);
+}
+
+void Footer::setData(FooterData data, int windowSizeY)
+{
+    this->data = data;
+    this->windowSizeY = windowSizeY;
+}

--- a/src/ui/Footer.cpp
+++ b/src/ui/Footer.cpp
@@ -27,10 +27,16 @@ void Footer::print() const
 
 void Footer::print(Vector2 offset) const
 {
+    int posY = windowSizeY - 1;
     attr_set(A_NORMAL, static_cast<ColorPair::NcPairID>(ReservedPairNumber::CURRENTCOLOR), NULL);
-    mvprintw(windowSizeY - 1, 0, "  ");
+    mvprintw(posY, 0, "  ");
 
     attr_set(A_NORMAL, 0, NULL);
+
+    mvprintw(posY, 3, "(%d, %d, %d)", 
+             data.currentRgb.r, 
+             data.currentRgb.g,
+             data.currentRgb.b);
     
     mvprintw(windowSizeY - 1, 20, "%d,%d", data.cursorPos.x, data.cursorPos.y);
 }


### PR DESCRIPTION
### 概要 (Summary)
`include/core/KeyConstants.hpp`で指定したRGB値増減のキーによって設定された現在の色をキャンバスに描画するようにした。

### 関連Issue
Closes #2   

### 変更点 (Detailed Changes)
- `include/core/KeyConstants.hpp`: キーコンフィグ用クラスの作成
- `include/ui/Footer.hpp`: カーソル位置や現在の色の情報を表示するUI部品描画クラス。
- `src/main.cpp`: キーバインド登録処理の追加と現在の色の増減、描画を行うようにした。

### テスト方法
- 設定したキーを入力すると現在のRGB値が変わり、フッターの色も変わることを確認。
- その選択した色でキャンバスに色を塗ることができることを確認。